### PR TITLE
replace deprecated attribute, clarify variables meaning

### DIFF
--- a/gitlab_integration/gitlab_fetcher.py
+++ b/gitlab_integration/gitlab_fetcher.py
@@ -210,9 +210,10 @@ def is_merge_request_opened(gitlab_payload) -> bool:
     判断是否是merge request打开事件
     """
     try:
-        gitlab_merge_request_old  = gitlab_payload.get("object_attributes").get("state") == "opened" and gitlab_payload.get("object_attributes").get("merge_status") == "preparing"
-        gitlab_merge_request_new = gitlab_payload.get("object_attributes").get("state") == "merged" and gitlab_payload.get("object_attributes").get("merge_status") == "can_be_merged"
-        return gitlab_merge_request_old or gitlab_merge_request_new
+        # 添加 "update" 支持更新事件, 添加 "reopen" 支持重新打开事件
+        gitlab_merge_request_new_version = gitlab_payload.get("object_attributes").get("state") == "opened" and gitlab_payload.get("object_attributes").get("action") in ["open"]
+        gitlab_merge_request_old_version = gitlab_payload.get("object_attributes").get("state") == "merged" and gitlab_payload.get("object_attributes").get("merge_status") == "can_be_merged"
+        return gitlab_merge_request_new_version or gitlab_merge_request_old_version
     except Exception as e:
         log.error(f"判断是否是merge request打开事件失败: {e}")
         return False


### PR DESCRIPTION
- "merge_status" is deprecated in gitlab new version, use action instead
[gitlab docs: Merge request events](https://docs.gitlab.com/user/project/integrations/webhook_events/#merge-request-events)
![image](https://github.com/user-attachments/assets/047e53ba-bccc-4e44-b9bb-7d486c27052e)

- Clarify variables meaning: variable new_version corresponds to newer version of gitlab (such as v16, v17); old_version corresponds to older version of gitlab (such as v13)

- Another issue that exists with or without this commit is that sometimes an unexpected AI comment will be triggered after an MR merged. (gitlab v16)