### PR TITLE
fix: think 标签格式混乱；支持评论折叠

### DIFF
--- a/review_engine/handler/default_handler.py
+++ b/review_engine/handler/default_handler.py
@@ -144,13 +144,13 @@ def generate_review_note_with_context(change, model, gitlab_fetcher, merge_info)
         model.generate_text(messages)
         log.info(f'对 {new_path} review中...')
         response_content = model.get_respond_content().replace('\n\n', '\n')
-        response_content = '<details><summary>Review Note</summary>\n' + response_content.replace(
+        response_content = response_content.replace(
             '<think>',
             '<details><summary>已深度思考</summary>\n<think>'
         ).replace(
             '</think>',
             '</think>\n</details>\n'
-        ) + '\n</details>'
+        )
         total_tokens = model.get_respond_tokens()
 
         # response

--- a/review_engine/handler/default_handler.py
+++ b/review_engine/handler/default_handler.py
@@ -144,6 +144,13 @@ def generate_review_note_with_context(change, model, gitlab_fetcher, merge_info)
         model.generate_text(messages)
         log.info(f'对 {new_path} review中...')
         response_content = model.get_respond_content().replace('\n\n', '\n')
+        response_content = '<details><summary>Review Note</summary>\n' + response_content.replace(
+            '<think>',
+            '<details><summary>已深度思考</summary>\n<think>'
+        ).replace(
+            '</think>',
+            '</think>\n</details>\n'
+        ) + '\n</details>'
         total_tokens = model.get_respond_tokens()
 
         # response


### PR DESCRIPTION
deepseek 返回的内容中有 \</think\> 标签，在处理输出之后，这个标签后缺一个换行符，会导致网页上评论内容显示格式混乱（gitlab v16)，改为用 summary 标签包围。
同时将整段内容用 summary 包围，避免长评论翻动不方便。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced review note display with collapsible sections that clearly separate the main review content from additional insights for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->