### PR TITLE
feat: 配置管理后台页面增加login功能

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,12 @@ SQLITE_DATABASE=db.sqlite3
 
 # LLM、通知渠道及邮件等配置已迁移至数据库（请通过后台管理进行设置）
 
+# 后台管理登录配置
+DEFAULT_USERNAME=your-username-here
+DEFAULT_PASSWORD=your-password-here
+# Token 过期时间（秒），默认 604800 秒 = 7 天
+TOKEN_EXPIRE_SECONDS=604800
+
 # =============================================================================
 # Redis 配置
 # =============================================================================
@@ -32,10 +38,6 @@ VITE_API_BASE_URL=/api
 VITE_APP_TITLE=Code Review Admin
 VITE_APP_DESCRIPTION=AI代码审查管理系统
 VITE_DEV_PROXY_TARGET=http://backend:8000
-
-# 前端登录配置
-VITE_DEFAULT_USERNAME=admin
-VITE_DEFAULT_PASSWORD=admin123
 
 # =============================================================================
 # 文件过滤配置

--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,10 @@ VITE_APP_TITLE=Code Review Admin
 VITE_APP_DESCRIPTION=AI代码审查管理系统
 VITE_DEV_PROXY_TARGET=http://backend:8000
 
+# 前端登录配置
+VITE_DEFAULT_USERNAME=admin
+VITE_DEFAULT_PASSWORD=admin123
+
 # =============================================================================
 # 文件过滤配置
 # =============================================================================

--- a/backend/apps/api_auth/urls.py
+++ b/backend/apps/api_auth/urls.py
@@ -1,0 +1,11 @@
+"""
+认证相关 URL 配置
+"""
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('login', views.login, name='auth_login'),
+    path('logout', views.logout, name='auth_logout'),
+    path('check', views.check_auth, name='auth_check'),
+]

--- a/backend/apps/api_auth/views.py
+++ b/backend/apps/api_auth/views.py
@@ -1,0 +1,153 @@
+"""
+认证相关视图
+"""
+import os
+import secrets
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
+import json
+from utils.redis_client import redis_client
+
+
+# Token 过期时间（秒）
+TOKEN_EXPIRE_SECONDS = int(os.environ.get('TOKEN_EXPIRE_SECONDS', 604800))  # 默认 7 天
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def login(request):
+    """
+    登录接口
+    从环境变量读取默认账号密码进行验证
+    使用 HttpOnly Cookie 存储 token
+    """
+    try:
+        # 解析请求数据
+        data = json.loads(request.body)
+        username = data.get('username', '').strip()
+        password = data.get('password', '').strip()
+
+        # 从环境变量读取配置的账号密码
+        default_username = os.environ.get('DEFAULT_USERNAME', 'admin')
+        default_password = os.environ.get('DEFAULT_PASSWORD', 'admin123')
+
+        # 验证账号密码
+        if username == default_username and password == default_password:
+            # 生成 token（使用 secrets 生成安全的随机 token）
+            token = secrets.token_urlsafe(32)
+
+            # 将 token 存储到 Redis，设置过期时间
+            redis_client.set_token(token, username, TOKEN_EXPIRE_SECONDS)
+
+            # 创建响应
+            response = JsonResponse({
+                'success': True,
+                'message': '登录成功',
+                'data': {
+                    'username': username,
+                    'expire_days': TOKEN_EXPIRE_SECONDS // 86400
+                }
+            })
+
+            # 设置 HttpOnly Cookie
+            response.set_cookie(
+                key='auth_token',
+                value=token,
+                max_age=TOKEN_EXPIRE_SECONDS,  # Cookie 过期时间
+                httponly=True,  # 防止 JavaScript 访问
+                secure=False,  # 生产环境应设置为 True（需要 HTTPS）
+                samesite='Lax'  # 防止 CSRF 攻击
+            )
+
+            return response
+        else:
+            return JsonResponse({
+                'success': False,
+                'message': '用户名或密码错误'
+            }, status=401)
+
+    except json.JSONDecodeError:
+        return JsonResponse({
+            'success': False,
+            'message': '请求数据格式错误'
+        }, status=400)
+    except Exception as e:
+        return JsonResponse({
+            'success': False,
+            'message': f'登录失败: {str(e)}'
+        }, status=500)
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def logout(request):
+    """
+    登出接口
+    删除 Redis 中的 token 并清除 Cookie
+    """
+    try:
+        # 从 Cookie 获取 token
+        token = request.COOKIES.get('auth_token')
+
+        if token:
+            # 从 Redis 删除 token
+            redis_client.delete_token(token)
+
+        # 创建响应
+        response = JsonResponse({
+            'success': True,
+            'message': '登出成功'
+        })
+
+        # 删除 Cookie
+        response.delete_cookie('auth_token')
+
+        return response
+    except Exception as e:
+        return JsonResponse({
+            'success': False,
+            'message': f'登出失败: {str(e)}'
+        }, status=500)
+
+
+@csrf_exempt
+@require_http_methods(["GET"])
+def check_auth(request):
+    """
+    检查认证状态接口
+    从 Cookie 读取 token 并验证 Redis 中是否存在
+    """
+    try:
+        # 从 Cookie 获取 token
+        token = request.COOKIES.get('auth_token')
+
+        if not token:
+            return JsonResponse({
+                'success': False,
+                'message': '未提供认证信息'
+            }, status=401)
+
+        # 从 Redis 验证 token
+        username = redis_client.get_token(token)
+
+        if username:
+            return JsonResponse({
+                'success': True,
+                'message': '已登录',
+                'data': {
+                    'username': username
+                }
+            })
+        else:
+            return JsonResponse({
+                'success': False,
+                'message': 'Token 已过期或无效'
+            }, status=401)
+
+    except Exception as e:
+        return JsonResponse({
+            'success': False,
+            'message': f'验证失败: {str(e)}'
+        }, status=500)
+

--- a/backend/apps/api_auth/views.py
+++ b/backend/apps/api_auth/views.py
@@ -29,8 +29,14 @@ def login(request):
         password = data.get('password', '').strip()
 
         # 从环境变量读取配置的账号密码
-        default_username = os.environ.get('DEFAULT_USERNAME', 'admin')
-        default_password = os.environ.get('DEFAULT_PASSWORD', 'admin123')
+        default_username = os.environ.get('DEFAULT_USERNAME', '')
+        default_password = os.environ.get('DEFAULT_PASSWORD', '')
+
+        if not default_username or not default_password:
+            return JsonResponse({
+                'success': False,
+                'message': '服务端未配置登录凭据'
+            }, status=500)
 
         # 验证账号密码
         if username == default_username and password == default_password:
@@ -38,7 +44,11 @@ def login(request):
             token = secrets.token_urlsafe(32)
 
             # 将 token 存储到 Redis，设置过期时间
-            redis_client.set_token(token, username, TOKEN_EXPIRE_SECONDS)
+            if not redis_client.set_token(token, username, TOKEN_EXPIRE_SECONDS):
+                return JsonResponse({
+                    'success': False,
+                    'message': 'Token 存储失败'
+                }, status=503)
 
             # 创建响应
             response = JsonResponse({

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -5,6 +5,19 @@ Django settings for Code Review GPT project.
 import os
 from pathlib import Path
 
+# 加载环境变量
+try:
+    from dotenv import load_dotenv
+    # .env 文件在项目根目录（backend 的上一级）
+    env_path = Path(__file__).resolve().parent.parent.parent / '.env'
+    if env_path.exists():
+        load_dotenv(dotenv_path=env_path)
+        print(f"✓ 已加载环境变量文件: {env_path}")
+    else:
+        print(f"⚠ 环境变量文件不存在: {env_path}")
+except ImportError:
+    print("⚠ python-dotenv 未安装，将使用系统环境变量")
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -31,6 +31,7 @@ INSTALLED_APPS = [
     'apps.review',
     'apps.response',
     'apps.llm',
+    'apps.api_auth',
 ]
 
 MIDDLEWARE = [

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -7,6 +7,7 @@ from django.http import JsonResponse
 from apps.webhook import urls as webhook_urls
 from apps.review import urls as review_urls
 from apps.llm import urls as llm_urls
+from apps.api_auth import urls as auth_urls
 import psutil
 import time
 from datetime import datetime
@@ -89,6 +90,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('health/', health_check, name='health_check'),
     path('api/system/info', system_info, name='system_info'),
+    path('api/auth/', include(auth_urls)),
     path('api/webhook/', include(webhook_urls)),
     path('api/review/', include(review_urls)),
     path('api/', include(llm_urls)),

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -34,3 +34,6 @@ python-dotenv==1.0.0
 
 # System Information
 psutil==5.9.8
+
+# Redis Support
+redis==5.0.1

--- a/backend/utils/redis_client.py
+++ b/backend/utils/redis_client.py
@@ -32,9 +32,7 @@ class RedisClient:
                 print(f"✓ Redis 连接成功: {redis_url}")
             except Exception as e:
                 print(f"✗ Redis 连接失败: {e}")
-                print("  将使用内存存储（仅用于开发环境）")
-                self._client = None
-                self._memory_store = {}
+                raise RuntimeError(f"Redis 连接失败，认证功能需要 Redis 支持: {redis_url}") from e
 
     def get_client(self):
         """获取 Redis 客户端"""
@@ -49,15 +47,11 @@ class RedisClient:
         :return: 是否成功
         """
         try:
-            if self._client:
-                self._client.setex(
-                    f"auth_token:{token}",
-                    expire_seconds,
-                    username
-                )
-            else:
-                # 内存存储（仅用于开发）
-                self._memory_store[f"auth_token:{token}"] = username
+            self._client.setex(
+                f"auth_token:{token}",
+                expire_seconds,
+                username
+            )
             return True
         except Exception as e:
             print(f"存储 token 失败: {e}")
@@ -70,12 +64,8 @@ class RedisClient:
         :return: 用户名，如果不存在或已过期返回 None
         """
         try:
-            if self._client:
-                username = self._client.get(f"auth_token:{token}")
-                return username
-            else:
-                # 内存存储（仅用于开发）
-                return self._memory_store.get(f"auth_token:{token}")
+            username = self._client.get(f"auth_token:{token}")
+            return username
         except Exception as e:
             print(f"获取 token 失败: {e}")
             return None
@@ -87,11 +77,7 @@ class RedisClient:
         :return: 是否成功
         """
         try:
-            if self._client:
-                self._client.delete(f"auth_token:{token}")
-            else:
-                # 内存存储（仅用于开发）
-                self._memory_store.pop(f"auth_token:{token}", None)
+            self._client.delete(f"auth_token:{token}")
             return True
         except Exception as e:
             print(f"删除 token 失败: {e}")
@@ -105,11 +91,7 @@ class RedisClient:
         :return: 是否成功
         """
         try:
-            if self._client:
-                return self._client.expire(f"auth_token:{token}", expire_seconds)
-            else:
-                # 内存存储不支持过期时间刷新
-                return True
+            return self._client.expire(f"auth_token:{token}", expire_seconds)
         except Exception as e:
             print(f"刷新 token 失败: {e}")
             return False

--- a/backend/utils/redis_client.py
+++ b/backend/utils/redis_client.py
@@ -1,0 +1,119 @@
+"""
+Redis 客户端工具类
+用于管理认证 token
+"""
+import os
+import redis
+from typing import Optional
+
+
+class RedisClient:
+    """Redis 客户端单例"""
+    _instance = None
+    _client = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        if self._client is None:
+            redis_url = os.environ.get('REDIS_URL', 'redis://localhost:6379/0')
+            try:
+                self._client = redis.from_url(
+                    redis_url,
+                    decode_responses=True,
+                    socket_connect_timeout=5,
+                    socket_timeout=5
+                )
+                # 测试连接
+                self._client.ping()
+                print(f"✓ Redis 连接成功: {redis_url}")
+            except Exception as e:
+                print(f"✗ Redis 连接失败: {e}")
+                print("  将使用内存存储（仅用于开发环境）")
+                self._client = None
+                self._memory_store = {}
+
+    def get_client(self):
+        """获取 Redis 客户端"""
+        return self._client
+
+    def set_token(self, token: str, username: str, expire_seconds: int = 604800) -> bool:
+        """
+        存储 token
+        :param token: token 字符串
+        :param username: 用户名
+        :param expire_seconds: 过期时间（秒），默认 7 天
+        :return: 是否成功
+        """
+        try:
+            if self._client:
+                self._client.setex(
+                    f"auth_token:{token}",
+                    expire_seconds,
+                    username
+                )
+            else:
+                # 内存存储（仅用于开发）
+                self._memory_store[f"auth_token:{token}"] = username
+            return True
+        except Exception as e:
+            print(f"存储 token 失败: {e}")
+            return False
+
+    def get_token(self, token: str) -> Optional[str]:
+        """
+        获取 token 对应的用户名
+        :param token: token 字符串
+        :return: 用户名，如果不存在或已过期返回 None
+        """
+        try:
+            if self._client:
+                username = self._client.get(f"auth_token:{token}")
+                return username
+            else:
+                # 内存存储（仅用于开发）
+                return self._memory_store.get(f"auth_token:{token}")
+        except Exception as e:
+            print(f"获取 token 失败: {e}")
+            return None
+
+    def delete_token(self, token: str) -> bool:
+        """
+        删除 token
+        :param token: token 字符串
+        :return: 是否成功
+        """
+        try:
+            if self._client:
+                self._client.delete(f"auth_token:{token}")
+            else:
+                # 内存存储（仅用于开发）
+                self._memory_store.pop(f"auth_token:{token}", None)
+            return True
+        except Exception as e:
+            print(f"删除 token 失败: {e}")
+            return False
+
+    def refresh_token(self, token: str, expire_seconds: int = 604800) -> bool:
+        """
+        刷新 token 过期时间
+        :param token: token 字符串
+        :param expire_seconds: 过期时间（秒），默认 7 天
+        :return: 是否成功
+        """
+        try:
+            if self._client:
+                return self._client.expire(f"auth_token:{token}", expire_seconds)
+            else:
+                # 内存存储不支持过期时间刷新
+                return True
+        except Exception as e:
+            print(f"刷新 token 失败: {e}")
+            return False
+
+
+# 创建全局实例
+redis_client = RedisClient()

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -350,3 +350,29 @@ export const testClaudeCliConfigApi = (data: any) => {
     timeout: 90000  // 90 秒超时（后端测试最多 45 秒 + 额外处理时间）
   })
 }
+
+// 认证相关 API
+// 登录
+export const login = (data: { username: string; password: string }) => {
+  return request({
+    url: getApiUrl('/auth/login'),
+    method: 'post',
+    data
+  })
+}
+
+// 登出
+export const logout = () => {
+  return request({
+    url: getApiUrl('/auth/logout'),
+    method: 'post'
+  })
+}
+
+// 检查认证状态
+export const checkAuth = () => {
+  return request({
+    url: getApiUrl('/auth/check'),
+    method: 'get'
+  })
+}

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -125,6 +125,14 @@
           </div>
 
           <div class="flex items-center gap-2">
+            <!-- User Info -->
+            <div class="flex items-center gap-2 px-3 py-2 rounded-xl bg-apple-100 text-apple-700">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+              </svg>
+              <span class="text-sm font-medium">{{ authStore.username }}</span>
+            </div>
+
             <button
               @click="handleRefresh"
               class="p-2.5 text-apple-600 hover:bg-apple-100 rounded-xl transition-all duration-200 active:scale-95"
@@ -133,6 +141,15 @@
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
               </svg>
+            </button>
+
+            <!-- Logout Button -->
+            <button
+              @click="handleLogout"
+              class="p-2.5 text-red-600 hover:bg-red-50 rounded-xl transition-all duration-200 active:scale-95"
+              title="登出"
+            >
+              <LogOut class="w-5 h-5" />
             </button>
           </div>
         </div>
@@ -147,22 +164,70 @@
         </router-view>
       </main>
     </div>
+
+    <!-- Logout Confirmation Modal -->
+    <transition name="modal">
+      <div
+        v-if="showLogoutModal"
+        class="fixed inset-0 z-[100] flex items-center justify-center bg-black/30 backdrop-blur-sm"
+        @click.self="showLogoutModal = false"
+      >
+        <div class="bg-white rounded-2xl shadow-2xl p-6 max-w-sm w-full mx-4 transform transition-all">
+          <!-- Icon -->
+          <div class="flex justify-center mb-4">
+            <div class="w-16 h-16 rounded-full bg-red-50 flex items-center justify-center">
+              <LogOut class="w-8 h-8 text-red-600" />
+            </div>
+          </div>
+
+          <!-- Title -->
+          <h3 class="text-xl font-semibold text-apple-900 text-center mb-2">
+            退出登录
+          </h3>
+
+          <!-- Message -->
+          <p class="text-apple-600 text-center mb-6">
+            确定要退出当前账号吗？
+          </p>
+
+          <!-- Buttons -->
+          <div class="flex gap-3">
+            <button
+              @click="showLogoutModal = false"
+              class="flex-1 px-4 py-3 rounded-xl border border-apple-300 text-apple-700 font-medium hover:bg-apple-50 transition-colors"
+            >
+              取消
+            </button>
+            <button
+              @click="confirmLogout"
+              class="flex-1 px-4 py-3 rounded-xl bg-red-600 text-white font-medium hover:bg-red-700 transition-colors"
+            >
+              退出
+            </button>
+          </div>
+        </div>
+      </div>
+    </transition>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import {
   FileText,
   Settings,
   ScrollText,
   Info,
-  FolderKanban
+  FolderKanban,
+  LogOut
 } from 'lucide-vue-next'
+import { useAuthStore } from '@/stores/auth'
 
 const route = useRoute()
 const router = useRouter()
+const authStore = useAuthStore()
+const showLogoutModal = ref(false)
 
 // Kept for future dynamic menu if needed
 // const menuRoutes = computed(() => {
@@ -201,6 +266,16 @@ const getCurrentTime = () => {
 const handleRefresh = () => {
   router.go(0)
 }
+
+const handleLogout = () => {
+  showLogoutModal.value = true
+}
+
+const confirmLogout = () => {
+  authStore.logout()
+  showLogoutModal.value = false
+  router.push('/login')
+}
 </script>
 
 <style scoped>
@@ -212,5 +287,29 @@ const handleRefresh = () => {
 .fade-enter-from,
 .fade-leave-to {
   opacity: 0;
+}
+
+/* Modal 动画 */
+.modal-enter-active {
+  transition: all 0.3s ease;
+}
+
+.modal-leave-active {
+  transition: all 0.2s ease;
+}
+
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+
+.modal-enter-from > div,
+.modal-leave-to > div {
+  transform: scale(0.9) translateY(-20px);
+}
+
+.modal-enter-active > div,
+.modal-leave-active > div {
+  transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 </style>

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -271,8 +271,8 @@ const handleLogout = () => {
   showLogoutModal.value = true
 }
 
-const confirmLogout = () => {
-  authStore.logout()
+const confirmLogout = async () => {
+  await authStore.logout()
   showLogoutModal.value = false
   router.push('/login')
 }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -79,9 +79,11 @@ const router = createRouter({
 })
 
 // 路由守卫
-router.beforeEach((to, from, next) => {
+router.beforeEach(async (to, from, next) => {
   const authStore = useAuthStore()
-  authStore.checkAuth()
+
+  // 异步检查认证状态
+  await authStore.checkAuth()
 
   // 如果路由需要认证且用户未登录，跳转到登录页
   if (to.meta.requiresAuth && !authStore.isAuthenticated) {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,11 +1,19 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import type { RouteRecordRaw } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
 
 const routes: RouteRecordRaw[] = [
+  {
+    path: '/login',
+    name: 'Login',
+    component: () => import('@/views/Login.vue'),
+    meta: { title: '登录', requiresAuth: false }
+  },
   {
     path: '/',
     component: () => import('@/layouts/MainLayout.vue'),
     redirect: '/projects',
+    meta: { requiresAuth: true },
     children: [
       {
         path: 'dashboard',
@@ -56,12 +64,36 @@ const routes: RouteRecordRaw[] = [
         meta: { title: '项目信息', icon: 'Info' }
       }
     ]
+  },
+  // 404 页面
+  {
+    path: '/:pathMatch(.*)*',
+    name: 'NotFound',
+    redirect: '/projects'
   }
 ]
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes
+})
+
+// 路由守卫
+router.beforeEach((to, from, next) => {
+  const authStore = useAuthStore()
+  authStore.checkAuth()
+
+  // 如果路由需要认证且用户未登录，跳转到登录页
+  if (to.meta.requiresAuth && !authStore.isAuthenticated) {
+    next('/login')
+  }
+  // 如果已登录且访问登录页，跳转到首页
+  else if (to.path === '/login' && authStore.isAuthenticated) {
+    next('/projects')
+  }
+  else {
+    next()
+  }
 })
 
 export default router

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -1,56 +1,87 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
+import * as api from '@/api'
 
 export const useAuthStore = defineStore('auth', () => {
   const isAuthenticated = ref(false)
   const username = ref('')
 
-  // 从环境变量读取默认账号密码
-  const DEFAULT_USERNAME = import.meta.env.VITE_DEFAULT_USERNAME
-  const DEFAULT_PASSWORD = import.meta.env.VITE_DEFAULT_PASSWORD
-
   /**
-   * 登录方法
+   * 登录方法 - 调用后端 API 验证
+   * 后端会自动设置 HttpOnly Cookie
    * @param user 用户名
    * @param pass 密码
    * @returns 登录是否成功
    */
-  const login = (user: string, pass: string): boolean => {
-    if (user === DEFAULT_USERNAME && pass === DEFAULT_PASSWORD) {
-      // 生成简单的 token（base64 编码）
-      const token = btoa(`${user}:${Date.now()}`)
-      localStorage.setItem('auth_token', token)
-      localStorage.setItem('username', user)
-      isAuthenticated.value = true
-      username.value = user
-      return true
+  const login = async (user: string, pass: string): Promise<boolean> => {
+    try {
+      const response: any = await api.login({
+        username: user,
+        password: pass
+      })
+
+      if (response.success && response.data) {
+        // 后端已经设置了 HttpOnly Cookie，前端不需要手动管理 token
+        // 只需要保存用户名到 localStorage 用于显示
+        localStorage.setItem('username', response.data.username)
+        isAuthenticated.value = true
+        username.value = response.data.username
+        return true
+      }
+      return false
+    } catch (error) {
+      console.error('登录失败:', error)
+      return false
     }
-    return false
   }
 
   /**
    * 登出方法
+   * 后端会自动清除 Cookie
    */
-  const logout = () => {
-    localStorage.removeItem('auth_token')
-    localStorage.removeItem('username')
-    isAuthenticated.value = false
-    username.value = ''
+  const logout = async () => {
+    try {
+      await api.logout()
+    } catch (error) {
+      console.error('登出失败:', error)
+    } finally {
+      // 清除本地存储的用户名
+      localStorage.removeItem('username')
+      isAuthenticated.value = false
+      username.value = ''
+    }
   }
 
   /**
    * 检查登录状态
+   * 通过调用后端接口验证 Cookie 中的 token 是否有效
    * @returns 是否已登录
    */
-  const checkAuth = (): boolean => {
-    const token = localStorage.getItem('auth_token')
-    const savedUsername = localStorage.getItem('username')
-    if (token && savedUsername) {
-      isAuthenticated.value = true
-      username.value = savedUsername
-      return true
+  const checkAuth = async (): Promise<boolean> => {
+    try {
+      const savedUsername = localStorage.getItem('username')
+      if (!savedUsername) {
+        return false
+      }
+
+      // 调用后端接口验证 Cookie 中的 token
+      const response: any = await api.checkAuth()
+
+      if (response.success && response.data) {
+        isAuthenticated.value = true
+        username.value = response.data.username
+        // 更新本地存储的用户名
+        localStorage.setItem('username', response.data.username)
+        return true
+      }
+      return false
+    } catch (error) {
+      // Token 无效或已过期
+      localStorage.removeItem('username')
+      isAuthenticated.value = false
+      username.value = ''
+      return false
     }
-    return false
   }
 
   return {

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -1,0 +1,63 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+
+export const useAuthStore = defineStore('auth', () => {
+  const isAuthenticated = ref(false)
+  const username = ref('')
+
+  // 从环境变量读取默认账号密码
+  const DEFAULT_USERNAME = import.meta.env.VITE_DEFAULT_USERNAME
+  const DEFAULT_PASSWORD = import.meta.env.VITE_DEFAULT_PASSWORD
+
+  /**
+   * 登录方法
+   * @param user 用户名
+   * @param pass 密码
+   * @returns 登录是否成功
+   */
+  const login = (user: string, pass: string): boolean => {
+    if (user === DEFAULT_USERNAME && pass === DEFAULT_PASSWORD) {
+      // 生成简单的 token（base64 编码）
+      const token = btoa(`${user}:${Date.now()}`)
+      localStorage.setItem('auth_token', token)
+      localStorage.setItem('username', user)
+      isAuthenticated.value = true
+      username.value = user
+      return true
+    }
+    return false
+  }
+
+  /**
+   * 登出方法
+   */
+  const logout = () => {
+    localStorage.removeItem('auth_token')
+    localStorage.removeItem('username')
+    isAuthenticated.value = false
+    username.value = ''
+  }
+
+  /**
+   * 检查登录状态
+   * @returns 是否已登录
+   */
+  const checkAuth = (): boolean => {
+    const token = localStorage.getItem('auth_token')
+    const savedUsername = localStorage.getItem('username')
+    if (token && savedUsername) {
+      isAuthenticated.value = true
+      username.value = savedUsername
+      return true
+    }
+    return false
+  }
+
+  return {
+    isAuthenticated,
+    username,
+    login,
+    logout,
+    checkAuth
+  }
+})

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 import { API_CONFIG } from '@/config/api'
+import router from '@/router'
 
 const service: AxiosInstance = axios.create({
   timeout: API_CONFIG.TIMEOUT,
@@ -10,7 +11,11 @@ const service: AxiosInstance = axios.create({
 // 请求拦截器
 service.interceptors.request.use(
   (config) => {
-    // 可以在这里添加token等
+    // 添加认证 token
+    const token = localStorage.getItem('auth_token')
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`
+    }
     return config
   },
   (error) => {
@@ -39,7 +44,11 @@ service.interceptors.response.use(
       const { status } = error.response
       switch (status) {
         case 401:
-          alert('未授权，请重新登录')
+          // 未授权，清除登录状态并跳转到登录页
+          localStorage.removeItem('auth_token')
+          localStorage.removeItem('username')
+          router.push('/login')
+          alert('登录已过期，请重新登录')
           break
         case 403:
           alert('拒绝访问')

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -5,17 +5,14 @@ import router from '@/router'
 
 const service: AxiosInstance = axios.create({
   timeout: API_CONFIG.TIMEOUT,
-  headers: API_CONFIG.HEADERS
+  headers: API_CONFIG.HEADERS,
+  withCredentials: true  // 允许携带 Cookie
 })
 
 // 请求拦截器
 service.interceptors.request.use(
   (config) => {
-    // 添加认证 token
-    const token = localStorage.getItem('auth_token')
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
+    // Cookie 会自动携带，不需要手动添加 Authorization header
     return config
   },
   (error) => {
@@ -41,11 +38,18 @@ service.interceptors.response.use(
     console.error('Response error:', error)
 
     if (error.response) {
-      const { status } = error.response
+      const { status, config } = error.response
+
+      // 判断是否是登录接口
+      const isLoginRequest = config.url?.includes('/auth/login')
+
       switch (status) {
         case 401:
-          // 未授权，清除登录状态并跳转到登录页
-          localStorage.removeItem('auth_token')
+          // 如果是登录接口返回 401，不做任何处理，让登录页面自己处理错误提示
+          if (isLoginRequest) {
+            break
+          }
+          // 其他接口返回 401，说明 token 过期，清除用户名并跳转到登录页
           localStorage.removeItem('username')
           router.push('/login')
           alert('登录已过期，请重新登录')

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -113,10 +113,7 @@ const handleLogin = async () => {
   loading.value = true
 
   try {
-    // 模拟网络延迟
-    await new Promise(resolve => setTimeout(resolve, 500))
-
-    const success = authStore.login(formData.username, formData.password)
+    const success = await authStore.login(formData.username, formData.password)
 
     if (success) {
       // 登录成功，跳转到项目列表页

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -1,0 +1,140 @@
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-apple-blue-50 to-apple-purple-50 px-4">
+    <div class="max-w-md w-full">
+      <!-- Logo and Title -->
+      <div class="text-center mb-8">
+        <h1 class="text-3xl font-bold text-apple-gray-900 mb-2">Code Review Admin</h1>
+        <p class="text-apple-gray-600">AI代码审查管理系统</p>
+      </div>
+
+      <!-- Login Card -->
+      <div class="bg-white rounded-2xl shadow-xl p-8">
+        <h2 class="text-2xl font-semibold text-apple-gray-900 mb-6">登录</h2>
+
+        <form @submit.prevent="handleLogin">
+          <!-- Username Input -->
+          <div class="mb-4">
+            <label for="username" class="block text-sm font-medium text-apple-gray-700 mb-2">
+              用户名
+            </label>
+            <input
+              id="username"
+              v-model="formData.username"
+              type="text"
+              required
+              class="w-full px-4 py-3 border border-apple-gray-300 rounded-lg focus:ring-2 focus:ring-apple-blue-500 focus:border-transparent transition-all"
+              placeholder="请输入用户名"
+              :disabled="loading"
+            />
+          </div>
+
+          <!-- Password Input -->
+          <div class="mb-6">
+            <label for="password" class="block text-sm font-medium text-apple-gray-700 mb-2">
+              密码
+            </label>
+            <div class="relative">
+              <input
+                id="password"
+                v-model="formData.password"
+                :type="showPassword ? 'text' : 'password'"
+                required
+                class="w-full px-4 py-3 pr-12 border border-apple-gray-300 rounded-lg focus:ring-2 focus:ring-apple-blue-500 focus:border-transparent transition-all"
+                placeholder="请输入密码"
+                :disabled="loading"
+              />
+              <button
+                type="button"
+                @click="showPassword = !showPassword"
+                class="absolute right-3 top-1/2 -translate-y-1/2 p-1.5 text-apple-gray-500 hover:text-apple-gray-700 rounded-lg hover:bg-apple-gray-100 transition-all"
+                :disabled="loading"
+                tabindex="-1"
+              >
+                <EyeOff v-if="!showPassword" class="w-5 h-5" />
+                <Eye v-else class="w-5 h-5" />
+              </button>
+            </div>
+          </div>
+
+          <!-- Error Message -->
+          <div v-if="errorMessage" class="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg">
+            <p class="text-sm text-red-600">{{ errorMessage }}</p>
+          </div>
+
+          <!-- Login Button -->
+          <button
+            type="submit"
+            :disabled="loading"
+            class="w-full bg-apple-blue-600 hover:bg-apple-blue-700 text-white font-medium py-3 px-4 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <span v-if="!loading">登录</span>
+            <span v-else>登录中...</span>
+          </button>
+        </form>
+
+        <!-- Default Account Hint -->
+        <div class="mt-6 p-4 bg-apple-gray-50 rounded-lg">
+          <p class="text-xs text-apple-gray-600 text-center">
+            <!-- 默认账号密码在 .env 文件中配置 -->
+          </p>
+        </div>
+      </div>
+
+      <!-- Footer -->
+      <div class="text-center mt-6">
+        <p class="text-sm text-apple-gray-500">
+          © 2026 Code Review GPT GitLab
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+import { Eye, EyeOff } from 'lucide-vue-next'
+
+const router = useRouter()
+const authStore = useAuthStore()
+
+const formData = reactive({
+  username: '',
+  password: ''
+})
+
+const loading = ref(false)
+const errorMessage = ref('')
+const showPassword = ref(false)
+
+const handleLogin = async () => {
+  errorMessage.value = ''
+  loading.value = true
+
+  try {
+    // 模拟网络延迟
+    await new Promise(resolve => setTimeout(resolve, 500))
+
+    const success = authStore.login(formData.username, formData.password)
+
+    if (success) {
+      // 登录成功，跳转到项目列表页
+      router.push('/projects')
+    } else {
+      errorMessage.value = '用户名或密码错误'
+    }
+  } catch (error) {
+    errorMessage.value = '登录失败，请稍后重试'
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<style scoped>
+/* Apple 风格的输入框聚焦效果 */
+input:focus {
+  outline: none;
+}
+</style>


### PR DESCRIPTION
因服务需要和github或者gitlab交互，有部署到公网的可能性，因此在管理后台加上了登录认证，防止其他人恶意修改网站配置，和获取敏感信息
<img width="2517" height="1166" alt="image" src="https://github.com/user-attachments/assets/d45b1f9b-6cb2-451c-9bfb-8725d4bedba9" />
![Uploading image.png…]()


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a login page with username/password and visibility toggle.
  * Display current user in the header and a logout action with confirmation modal.
  * Routes now enforce authentication and redirect appropriately.
  * Server now supports cookie-based sessions with configurable expiry for persistent logins.

* **Bug Fixes**
  * Session expiry redirects to login and shows a "login expired" notification.
  * API requests now send session cookies automatically.

* **Chores**
  * Added configuration placeholders for default credentials and session expiry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->